### PR TITLE
Bugfix: Restore the program flow in the class hierarchy

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -42,5 +42,6 @@ class User extends User_parent
     protected function onChangeUserData($aInvAddress)
     {
         Accounting::doAccounting();
+        parent::onChangeUserData($aInvAddress);
     }
 }


### PR DESCRIPTION
The call `parent::onChangeUserData($aInvAddress);` was missing 
This destroyed our module inheritance chain. And in the OXID-EE its function was overridden.
